### PR TITLE
Fix: Change np.object0 to object

### DIFF
--- a/cartoreader_lite/low_level/utils.py
+++ b/cartoreader_lite/low_level/utils.py
@@ -164,7 +164,7 @@ def simplify_dataframe_dtypes(df : pd.DataFrame, dtype_dict : dict, inplace=True
 def interp1d_dtype(x : np.ndarray, y : np.ndarray, *args, **kwargs):
 
     #For complex objects (e.g. strings), just take the closest object
-    if y.dtype == np.object0 or y.dtype == str:
+    if y.dtype == object or y.dtype == str:
         kdtree = cKDTree(x[:, np.newaxis])
         interp_f = lambda x_query: y[kdtree.query(x_query[:, np.newaxis])[1]]
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,8 +30,8 @@ def test_convert_df_dtypes():
     df_conv = convert_df_dtypes(df, inplace=False)
     assert np.issubdtype(df_conv.a.dtype, np.integer)
     assert np.issubdtype(df_conv.b.dtype, np.floating)
-    assert np.issubdtype(df.a.dtype, np.object0)
-    assert np.issubdtype(df.b.dtype, np.object0)
+    assert np.issubdtype(df.a.dtype, object)
+    assert np.issubdtype(df.b.dtype, object)
 
     convert_df_dtypes(df, inplace=True)
     assert np.issubdtype(df.a.dtype, np.integer)


### PR DESCRIPTION
Running tests/test_utils.py throws the following error (numpy==2.4.1) AttributeError: module 'numpy' has no attribute 'object0' Changing np.object0 to object fixed this.