### PR TITLE
Fix: Handle PathLike filenames

### DIFF
--- a/cartoreader_lite/low_level/utils.py
+++ b/cartoreader_lite/low_level/utils.py
@@ -139,7 +139,7 @@ def snake_to_camel_case(name : str, capitalize=False) -> str:
     return ret
 
 def convert_fname_to_handle(file : Union[IO, PathLike], mode : str):
-    is_fname = issubclass(type(file), str)
+    is_fname = isinstance(file, (str, PathLike))
     if is_fname:
         #assert file.endswith("pkl.gz"), "Only allowed file type is currently pkl.gz"
         file = open(file, mode)


### PR DESCRIPTION
Previously, convert_fname_to_handle only handled strings, but PathLike object should be treated in the same way.